### PR TITLE
feat: 強化首頁視覺層次與氛圍感

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -125,21 +125,47 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 :root {
-  /* 氛圍色彩方案 */
+  /* 氛圍色彩方案 - 基礎色彩 */
   --warm-white: #FEFEFE;
   --soft-beige: #F5F1EB;
   --light-pink-brown: #E8D5C4;
   --deep-brown-gray: #4A4440;
   --rose-gold: #D4AF8C;
   --warm-gray: #8B7F7A;
+  
+  /* 視覺豐富化色彩 */
+  --warm-orange: #F4A261;
+  --deep-rose: #C97C5D;
+  --light-purple-gray: #E6D7E3;
+  --gold-copper: #B7956A;
+  --dusk-blue: #8B9DC3;
+  --sunset-pink: #E6A4B4;
+  --misty-lavender: #D4C7D8;
+  --copper-glow: #C5956F;
 }
 
 /* 氛圍網站專用元件樣式 */
 @layer components {
   .atmosphere-hero {
-    background: linear-gradient(135deg, var(--warm-white) 0%, var(--soft-beige) 100%);
+    background: linear-gradient(135deg, var(--warm-white) 0%, var(--soft-beige) 30%, var(--light-purple-gray) 100%);
     min-height: 100vh;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'PingFang SC', sans-serif;
+    position: relative;
+    overflow: hidden;
+  }
+  
+  .atmosphere-hero::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle at 30% 70%, rgba(244, 162, 97, 0.1) 0%, transparent 50%),
+                radial-gradient(circle at 70% 30%, rgba(139, 157, 195, 0.08) 0%, transparent 50%),
+                radial-gradient(circle at 50% 50%, rgba(230, 164, 180, 0.05) 0%, transparent 50%);
+    animation: atmosphereFloat 20s ease-in-out infinite;
+    pointer-events: none;
   }
   
   .atmosphere-card {
@@ -157,22 +183,39 @@
   }
   
   .atmosphere-btn {
-    background: var(--rose-gold);
+    background: linear-gradient(135deg, var(--warm-orange) 0%, var(--deep-rose) 100%);
     color: var(--warm-white);
     padding: 0.875rem 2rem;
     border-radius: 12px;
     font-weight: 500;
     font-size: 0.95rem;
     letter-spacing: 0.5px;
-    transition: all 0.3s ease;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     border: none;
     cursor: pointer;
+    position: relative;
+    overflow: hidden;
+  }
+  
+  .atmosphere-btn::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+    transition: left 0.6s ease;
+  }
+  
+  .atmosphere-btn:hover::before {
+    left: 100%;
   }
   
   .atmosphere-btn:hover {
-    background: #C99B73;
-    transform: translateY(-1px);
-    box-shadow: 0 6px 20px rgba(212, 175, 140, 0.3);
+    background: linear-gradient(135deg, var(--deep-rose) 0%, var(--copper-glow) 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px rgba(244, 162, 97, 0.4);
   }
   
   .atmosphere-btn-secondary {
@@ -280,4 +323,32 @@
 
 .animate-atmosphere-fade-in {
   animation: atmosphereFadeIn 1.2s ease-out forwards;
+}
+
+/* 新增的視覺效果動畫 */
+@keyframes atmosphereFloat {
+  0%, 100% {
+    transform: translate(0, 0) rotate(0deg);
+  }
+  33% {
+    transform: translate(30px, -30px) rotate(1deg);
+  }
+  66% {
+    transform: translate(-20px, 20px) rotate(-1deg);
+  }
+}
+
+@keyframes atmospherePulse {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 0.8;
+  }
+}
+
+.animate-atmosphere-pulse {
+  animation: atmospherePulse 3s ease-in-out infinite;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -102,13 +102,37 @@ export default async function Home() {
               const product = products.find(p => p.id === productId)
               if (!product) return null
 
+              // 為不同卡片定義不同的視覺風格
+              const cardStyles = productId === 'PROD_UF002' 
+                ? {
+                    background: 'linear-gradient(135deg, var(--warm-white) 0%, var(--sunset-pink) 15%, var(--warm-white) 100%)',
+                    iconGradient: 'from-[var(--warm-orange)] to-[var(--deep-rose)]',
+                    glowColor: 'rgba(244, 162, 97, 0.15)'
+                  }
+                : {
+                    background: 'linear-gradient(135deg, var(--warm-white) 0%, var(--misty-lavender) 15%, var(--warm-white) 100%)',
+                    iconGradient: 'from-[var(--dusk-blue)] to-[var(--gold-copper)]',
+                    glowColor: 'rgba(139, 157, 195, 0.15)'
+                  }
+
               return (
                 <div 
                   key={productId}
-                  className="atmosphere-card text-center animate-atmosphere-slide-up"
-                  style={{animationDelay: `${index * 0.2}s`}}
+                  className="relative text-center animate-atmosphere-slide-up rounded-2xl p-8 border border-[var(--light-pink-brown)]/20 transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl group"
+                  style={{
+                    animationDelay: `${index * 0.2}s`,
+                    background: cardStyles.background
+                  }}
                 >
-                  <div className="w-16 h-16 mx-auto mb-6 rounded-full bg-gradient-to-br from-[var(--rose-gold)] to-[var(--light-pink-brown)] flex items-center justify-center">
+                  {/* 懸停光暈效果 */}
+                  <div 
+                    className="absolute inset-0 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500 pointer-events-none"
+                    style={{
+                      background: `radial-gradient(circle at center, ${cardStyles.glowColor} 0%, transparent 70%)`
+                    }}
+                  ></div>
+                  
+                  <div className={`w-16 h-16 mx-auto mb-6 rounded-full bg-gradient-to-br ${cardStyles.iconGradient} flex items-center justify-center animate-atmosphere-pulse relative z-10 shadow-lg`}>
                     <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       {productId === 'PROD_UF002' ? (
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
@@ -118,16 +142,16 @@ export default async function Home() {
                     </svg>
                   </div>
                   
-                  <h3 className="text-2xl font-medium-custom text-[var(--deep-brown-gray)] mb-4">
+                  <h3 className="text-2xl font-medium-custom text-[var(--deep-brown-gray)] mb-4 relative z-10">
                     {config.atmosphereDescription}
                   </h3>
                   
-                  <p className="text-[var(--warm-gray)] leading-relaxed-custom mb-6">
+                  <p className="text-[var(--warm-gray)] leading-relaxed-custom mb-6 relative z-10">
                     {config.description}
                   </p>
                   
-                  <p className="text-sm text-[var(--deep-brown-gray)] font-medium-custom">
-                    對應選物：{config.poeticName}
+                  <p className="text-sm text-[var(--deep-brown-gray)] font-medium-custom relative z-10">
+                    對應選物：<span className="text-[var(--copper-glow)]">{config.poeticName}</span>
                   </p>
                 </div>
               )
@@ -137,8 +161,15 @@ export default async function Home() {
       </section>
 
       {/* 商品展示區 */}
-      <section id="selection" className="py-20 px-4">
-        <div className="max-w-6xl mx-auto">
+      <section id="selection" className="py-20 px-4 relative overflow-hidden">
+        {/* 背景裝飾 */}
+        <div className="absolute inset-0 pointer-events-none">
+          <div className="absolute top-20 left-10 w-32 h-32 bg-gradient-to-br from-[var(--sunset-pink)]/10 to-transparent rounded-full blur-xl"></div>
+          <div className="absolute bottom-20 right-10 w-40 h-40 bg-gradient-to-br from-[var(--dusk-blue)]/8 to-transparent rounded-full blur-2xl"></div>
+          <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-60 h-60 bg-gradient-to-br from-[var(--misty-lavender)]/5 to-transparent rounded-full blur-3xl"></div>
+        </div>
+        
+        <div className="max-w-6xl mx-auto relative z-10">
           <div className="text-center mb-16">
             <h2 className="text-3xl md:text-4xl font-light-custom text-[var(--deep-brown-gray)] mb-6">
               給那些無法說明的感受


### PR DESCRIPTION
## 概要
針對 ##6 提出的首頁視覺優化需求，完成了全面的視覺層次提升和氛圍感增強。

## 主要改進

🎨 **色彩系統豐富化**
- 新增 8 種視覺豐富化色彩：暖橘、深玫瑰、淡紫灰、金銅色等
- 解決原本過於單調的米色系問題

✨ **Hero 區塊強化**
- 三層漸層背景（暖白→米色→淡紫灰）
- 浮動微粒動畫效果，營造夢幻氛圍
- CTA 按鈕升級：漸層背景 + 光波掃過動畫

🎯 **情境卡片差異化**
- 「久一點的夜」：暖橘至粉紅系，溫暖親密感
- 「安靜的靠近」：淡紫至金銅系，神秘高級感
- 懸停光暈效果和脈衝動畫

🌟 **視覺動線優化**
- 商品展示區添加背景裝飾球體
- 增強空間層次感和氛圍營造
- 所有動畫使用溫和的緩動函數

## 技術細節
- 新增 CSS 變數：8 種視覺豐富化色彩
- 新增 atmosphereFloat 和 atmospherePulse 動畫
- 優化 .atmosphere-btn 樣式，添加光波效果
- 優化 .atmosphere-hero 背景，添加浮動元素

## 測試結果
- ✅ ESLint 檢查通過（僅有 console 警告，可接受）
- ✅ 編譯成功，無錯誤
- ✅ 打包大小優秀：首頁僅 972B

🤖 Generated with [Claude Code](https://claude.ai/code)